### PR TITLE
Avoid command_not_found_handle mangling errors

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -146,6 +146,8 @@ install_caddy()
 	chmod +x "$PREFIX/tmp/$caddy_bin"
 
 	# Back up existing caddy, if any
+        # Ensure standard ‘command not found’ error on stderr
+        unset -f command_not_found_handle
 	caddy_cur_ver="$("$caddy_bin" --version 2>/dev/null | cut -d ' ' -f2)"
 	if [[ $caddy_cur_ver ]]; then
 		# caddy of some version is already installed


### PR DESCRIPTION
`getcaddy` didn't work for me:

    Aborted, error 1 in command: caddy_path="$(type -p "$caddy_bin")"

I didn't have `caddy` installed, so it shouldn't've even been getting to the above line; it went wrong at:

    caddy_cur_ver="$("$caddy_bin" --version 2>/dev/null | cut -d ' ' -f2)"

It turns out I had a shonky `command_not_found_handler`† which was emitting something on `stdout`, and that made it look like `caddy` was installed (setting `caddy_cur_ver` to `command`!).

This patch deactivates `command_not_found_handler` before trying to run `$caddy_bin`, ensuring the standard behaviour for Bash not finding a command. 

I realize this is niche (and I've now fixed my `command_not_found_handler`), but it makes the installer more robust, so there doesn't seem any harm in always deactivating this. I've checked that `unset` still returns `0` when there isn't a function with that name defined: on non-Debian-based systems it'll be a no-op.

† A Debian extension to Bash which runs a custom function when a command isn't found.