### PR TITLE
Fix trap not returning error code

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -28,7 +28,7 @@
 
 install_caddy()
 {
-	trap 'echo -e "Aborted, error $? in command: $BASH_COMMAND"; trap ERR; return 1' ERR
+	trap 'echo -e "Aborted, error $? in command: $BASH_COMMAND"; trap ERR; exit 1' ERR
 	caddy_os="unsupported"
 	caddy_arch="unknown"
 	caddy_arm=""


### PR DESCRIPTION
I've confirmed that, whenever this trap is executed...
* without this fix, the overall script returns 0.
* with this fix, the overall script returns 1.