### PR TITLE
Remove download after failed validation

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -201,7 +201,7 @@ install_caddy()
 			rm -- "$dl.asc"
 			echo "Download verification OK"
 		else
-			rm -- "$dl.asc"
+			rm -- "$dl.asc" "$dl"
 			echo "Aborted, download verification failed"
 			return 8
 		fi


### PR DESCRIPTION
If the scripts detects an invalid download it's safer to remove the
download. Getting downloads from an unexpectedly unverifiable source
might indicate a malicious action. Therefore the script should protect
the user from executing such a binary.