### PR TITLE
Extend signature validation to also check for the expected signer

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -197,7 +197,7 @@ install_caddy()
 		if ((!keyserver_ok))
 		then
 			echo "No valid response from keyservers"
-		elif gpg -q --batch --verify "$dl.asc" "$dl" >/dev/null 2>&1; then
+		elif gpg_verify_signature "$caddy_pgp" "$dl.asc" "$dl" >/dev/null 2>&1; then
 			rm -- "$dl.asc"
 			echo "Download verification OK"
 		else
@@ -238,5 +238,17 @@ install_caddy()
 	trap ERR
 	return 0
 }
+
+gpg_verify_signature()
+{
+	local fpr=${1:?fingerprint expected}
+	local sigpath=${2:?path expected}
+	local datapath=${3:-}
+	local tmpkeyring=$(mktemp)
+	trap 'rm -rf $tmpkeyring' RETURN
+	gpg -q --batch --export $fpr >$tmpkeyring
+	gpg -q --batch --verify --no-default-keyring --keyring $tmpkeyring -- $sigpath $datapath
+}
+
 
 install_caddy "$@"


### PR DESCRIPTION
This extends the verification of the OpenPGP signature to also check that the signer matches the previously fetch public key of the Caddy organisation, which is known by its fingerprint already.

Currently, the verification would also pass if ANY key in the user's public keyring had made the signature, which fails to verify the authenticity of the binary.

Since GnuPG does not directly offer the functionality to check whether a signature has been made by a given public key. I use a little workaround that has been [suggested on Super User](https://superuser.com/a/650359). It basically uses a temporary keyring which only contains the fingerprinted key and therefore prevents any unwanted false positives.